### PR TITLE
Set hostname to localhost for Vagrant VMs

### DIFF
--- a/tutorials/01VagrantSetup.md
+++ b/tutorials/01VagrantSetup.md
@@ -46,6 +46,18 @@ vagrant ssh
 
 You will now be connected to an `ssh` session on your virtual machine.
 
+By default, Vagrant VMs have a hostname of `localhost.localdomain`. You can check this issuing the command:
+```Shell
+hostname
+```
+
+This hostname can cause some issues with Payara and is slightly different to the standard `localhost` hostname used. To avoid issues later on, it is a good idea to change the hostname at this point:
+```Shell
+sudo hostname -b localhost
+```
+
+To check the change has been correctly applied, `hostname` should now output `localhost`.
+
 *Warning: Avoid issuing a `yum update` as it will install a new kernel which is not able to mount the directory shared between the host and virtual machines.*
 
 For a more detailed introduction to Vagrant, you could follow the tutorial on the Vagrant website [here](https://www.vagrantup.com/intro/getting-started/index.html "Vagrant Getting Started").

--- a/tutorials/03InstallingGlassFish.md
+++ b/tutorials/03InstallingGlassFish.md
@@ -80,7 +80,7 @@ To find the hostname of your VM:
 ```Shell
 hostname
 ```
-will output `localhost.localdomain` if you are using the Vagrant setup recommended in this tutorial.
+will output `localhost` if you are using the Vagrant setup recommended in this tutorial. If you are using a Vagrant VM and the hostname is set to `localhost.localdomain`, please follow the instructions in chapter 1 (Vagrant setup) to change the hostname to `localhost`. Once you have applied the change, re-run the `setup-glassfish.py` script as shown above.
 
 To find the Common Name (CN) of the certificate provided by Payara:
 ```Shell
@@ -88,8 +88,8 @@ echo | openssl s_client -connect localhost:8181  -showcerts 2> /dev/null | egrep
 ```
 will output:
 ```
-subject=/C=UK/ST=Worcestershire/L=Great Malvern/O=Payara Foundation/OU=Payara/CN=localhost.localdomain
-issuer=/C=UK/ST=Worcestershire/L=Great Malvern/O=Payara Foundation/OU=Payara/CN=localhost.localdomain
+subject=/C=UK/ST=Worcestershire/L=Great Malvern/O=Payara Foundation/OU=Payara/CN=localhost
+issuer=/C=UK/ST=Worcestershire/L=Great Malvern/O=Payara Foundation/OU=Payara/CN=localhost
 ```
 if you have followed the Vagrant setup.
 

--- a/tutorials/03InstallingGlassFish.md
+++ b/tutorials/03InstallingGlassFish.md
@@ -7,7 +7,7 @@ Chapter 03: Installing Payara
 
 Overview
 --------
-The Payara Application Server is installed by simply downloading a zip file and uncompressing it. The server is able to host multiple domains so we need to choose a domain name for our ICAT installation. In this tutorial, we will use the default domain name `domain1`. The files for the domain are stored under `payara5.2022.1/glassfish/domains/<domain_name>`, in our case `payara5.2022.1/glassfish/domains/domain1`.
+The Payara Application Server is installed by simply downloading a zip file and uncompressing it. The server is able to host multiple domains so we need to choose a domain name for our ICAT installation. In this tutorial, we will use the default domain name `domain1`. The files for the domain are stored under `payara5/glassfish/domains/<domain_name>`, in our case `payara5/glassfish/domains/domain1`.
 
 **NB: the commands on this page should be entered as the `glassfish` user**
 
@@ -34,7 +34,7 @@ Configure Payara
 Add the Payara directory to the path so we have access to the `asadmin` program which is used to administer the Payara application server. This step must be completed before running the script below as it uses the `asadmin` program.
 
 ```Shell
-echo 'export PATH=$HOME/payara5.2022.1/bin:$PATH' >> $HOME/.bashrc
+echo 'export PATH=$HOME/payara5/bin:$PATH' >> $HOME/.bashrc
 source $HOME/.bashrc
 ```
 Check that it works:
@@ -42,7 +42,7 @@ Check that it works:
 ```Shell
 which asadmin
 ```
-outputs: *~/payara5.2022.1/bin/asadmin*
+outputs: *~/payara5/bin/asadmin*
 
 Download a script to configure Payara for ICAT
 
@@ -64,7 +64,7 @@ Configure Payara for MariaDB
 We need the MySQL Connector library to enable ICAT to access the MariaDB database. This was installed to the system in the previous chapter. We need to copy the jar file to the correct directory - the `domain1` domain of the Payara server - then restart Payara so that it is found.
 
 ```Shell
-cp /usr/share/java/mysql-connector-java-5.1.17.jar $HOME/payara5.2022.1/glassfish/domains/domain1/lib/
+cp /usr/share/java/mysql-connector-java.jar $HOME/payara5/glassfish/domains/domain1/lib/
 asadmin stop-domain
 asadmin start-domain
 ```
@@ -108,6 +108,6 @@ Troubleshooting: Finding the Logs
 If you need to troubleshoot a problem, you can find the Payara logs at:
 
 ```Shell
-/home/glassfish/payara5.2022.1/glassfish/domains/domain1/logs/server.log
+/home/glassfish/payara5/glassfish/domains/domain1/logs/server.log
 ```
 

--- a/tutorials/04InstallingAuthentication.md
+++ b/tutorials/04InstallingAuthentication.md
@@ -25,13 +25,13 @@ unzip ~/downloads/authn.simple-2.0.1-distro.zip
 Configure the authentication plugin
 -----------------------------------
 
-Change directory to `authn.simple` and use your favourite editor to create the `setup.properties` file. The `container` in this tutorial is `Glassfish` (note the case) - since Payara is a fork of Glassfish - and the `home` points to the location of the Payara installation. In this tutorial it is `/home/glassfish/payara5.2022.1`. Finally we set the port for communication with the Payara server.
+Change directory to `authn.simple` and use your favourite editor to create the `setup.properties` file. The `container` in this tutorial is `Glassfish` (note the case) - since Payara is a fork of Glassfish - and the `home` points to the location of the Payara installation. In this tutorial it is `/home/glassfish/payara5`. Finally we set the port for communication with the Payara server.
 
 ```INI
 #Glassfish
 secure = true
 container = Glassfish
-home = /home/glassfish/payara5.2022.1
+home = /home/glassfish/payara5
 port = 4848
 ```
 

--- a/tutorials/05InstallingLuceneComponent.md
+++ b/tutorials/05InstallingLuceneComponent.md
@@ -32,7 +32,7 @@ setup.properties:
 #Glassfish
 secure = true
 container = Glassfish
-home = /home/glassfish/payara5.2022.1
+home = /home/glassfish/payara5
 port = 4848
 ```
 

--- a/tutorials/06InstallingICATServer.md
+++ b/tutorials/06InstallingICATServer.md
@@ -84,7 +84,7 @@ authn.list = simple
 !authn.ldap.admin    = true
 !authn.ldap.friendly = Federal Id
 
-authn.simple.url      = https://localhost.localdomain:8181
+authn.simple.url      = https://localhost:8181
 authn.simple.friendly = Simple
 
 !authn.anon.url      = https://localhost:8181
@@ -99,7 +99,7 @@ notification.Datafile = CU
 log.list = SESSION WRITE READ INFO
 
 # Lucene
-lucene.url = https://localhost.localdomain:8181
+lucene.url = https://localhost:8181
 lucene.populateBlockSize = 1000
 lucene.directory = /home/glassfish/data/lucene
 lucene.backlogHandlerIntervalSeconds = 60

--- a/tutorials/06InstallingICATServer.md
+++ b/tutorials/06InstallingICATServer.md
@@ -29,7 +29,7 @@ Change directory to the `icat.server` directory and open the `setup.properties` 
 #Glassfish
 secure = true
 container = Glassfish
-home = /home/glassfish/payara5.2022.1
+home = /home/glassfish/payara5
 port = 4848
 
 # MySQL

--- a/tutorials/07InstallingStoragePlugin.md
+++ b/tutorials/07InstallingStoragePlugin.md
@@ -29,7 +29,7 @@ Change directory to the `ids.storage_file` directory. Create `setup.properties` 
 #Glassfish
 secure = true
 container = Glassfish
-home = /home/glassfish/payara5.2022.1
+home = /home/glassfish/payara5
 port = 4848
 ```
 

--- a/tutorials/08ICATDataService.md
+++ b/tutorials/08ICATDataService.md
@@ -38,7 +38,7 @@ Change directory into `~/install/ids.server`. The `setup.properties` should be f
 #Glassfish
 secure = true
 container = Glassfish
-home = /home/glassfish/payara5.2022.1
+home = /home/glassfish/payara5
 port = 4848
 
 #Any libraries needed (space separated list of jars in domain's lib/applibs

--- a/tutorials/08ICATDataService.md
+++ b/tutorials/08ICATDataService.md
@@ -46,7 +46,7 @@ libraries=ids.storage_file*.jar
 ```
 
 The `run.properties` file is quite large but most of the parameters can safely be left as their default values. For this tutorial, we only need to tell the IDS where to find the ICAT Server, who the privileged users are, and where to find and store its data.
-* Set `icat.url` to the location of the ICAT Server: `https://localhost:8181`. The value of the FQDN in this URL must agree with the CN in the payara certificate that was generated during the installation of payara in [chapter 3](03InstallingGlassFish.md#check-the-certificate) of this tutorial and is obtained from the output of the `hostname` command. Here, the value of the FQDN is correct for a vagrant/virtualbox VM, which is `localhost.localdomain`.
+* Set `icat.url` to the location of the ICAT Server: `https://localhost:8181`. The value of the FQDN in this URL must agree with the CN in the payara certificate that was generated during the installation of payara in [chapter 3](03InstallingGlassFish.md#check-the-certificate) of this tutorial and is obtained from the output of the `hostname` command. Here, the value of the FQDN is correct for a vagrant/virtualbox VM, which is `localhost`.
 * Set the `plugin.main.dir` parameter to the point to the directory we created above: `/home/glassfish/data/main`.
 * Set the `cache.dir` parameter to the point to the directory we created above: `/home/glassfish/data/cache`.
 * Set the `rootUserNames` parameter to `simple/root` - the `root` user configured using the `simple` authentication mechanism. Users listed here are permitted to check the status of the whole IDS. More accounts could be listed here as a space-separated list.
@@ -56,7 +56,7 @@ The `run.properties` file is quite large but most of the parameters can safely b
 
 ```INI
 # General properties
-icat.url = https://localhost.localdomain:8181
+icat.url = https://localhost:8181
 
 plugin.zipMapper.class = org.icatproject.ids.storage.ZipMapper
 

--- a/tutorials/10TopCat.md
+++ b/tutorials/10TopCat.md
@@ -42,7 +42,7 @@ db.password    = icatdbuserpw
 
 secure = true
 container = Glassfish
-home = /home/glassfish/payara5.2022.1
+home = /home/glassfish/payara5
 port = 4848
 ```
 

--- a/tutorials/10TopCat.md
+++ b/tutorials/10TopCat.md
@@ -50,11 +50,11 @@ Copy the `topcat.properties.example` file to `topcat.properties`. We associate t
 ```INI
 facility.list = LILS
 
-facility.LILS.icatUrl = https://localhost.localdomain:8181
-facility.LILS.idsUrl = https://localhost.localdomain:8181
+facility.LILS.icatUrl = https://localhost:8181
+facility.LILS.idsUrl = https://localhost:8181
 
-facility.LILS.downloadType.http = http://localhost.localdomain:8080
-facility.LILS.downloadType.https = https://localhost.localdomain:8181
+facility.LILS.downloadType.http = http://localhost:8080
+facility.LILS.downloadType.https = https://localhost:8181
 
 # enable send email
 mail.enable = false
@@ -77,7 +77,7 @@ We only need to change the `topcat.json` file for this tutorial. As above, we ne
 ```JSON
 {
     "site": {
-        "topcatUrl": "https://localhost.localdomain:18181",
+        "topcatUrl": "https://localhost:18181",
 
 ...
 
@@ -86,8 +86,8 @@ We only need to change the `topcat.json` file for this tutorial. As above, we ne
         {
             "name": "LILS",
             "title": "Lorum Ipsum Light Source",
-            "idsUrl": "https://localhost.localdomain:18181",
-            "icatUrl": "https://localhost.localdomain:18181",
+            "idsUrl": "https://localhost:18181",
+            "icatUrl": "https://localhost:18181",
 
 ...
 
@@ -100,11 +100,11 @@ We only need to change the `topcat.json` file for this tutorial. As above, we ne
             "downloadTransportTypes": [
                 {
                     "type" : "http",
-                    "idsUrl": "http://localhost.localdomain:18080"
+                    "idsUrl": "http://localhost:18080"
                 },
                 {
                     "type" : "https",
-                    "idsUrl": "https://localhost.localdomain:18181"
+                    "idsUrl": "https://localhost:18181"
                 },
             ]
 
@@ -183,7 +183,7 @@ Log in to TopCat
 
 If you have followed all the steps in this tutorial successfully, you should have a working installation of the ICAT software loaded with test data. If you have used the suggested Vagrant setup from this tutorial you may now access your TopCat installation from your web browser by visiting the following URL:
 
-(https://localhost.localdomain:18181/)
+(https://localhost:18181/)
 
 selecting 'Lorum Ipsum Light Source' as the facility and entering 'root' and 'pw' as the username and password respectively.
 


### PR DESCRIPTION
This PR closes #10.

I've added some instructions to change the hostname from `localhost.localdomain` to `localhost` on Vagrant VMs. The command used to do this is the same command used in DataGateway's CI workflows resolve issues there. I have also tested the change on a fresh Centos 7 Vagrant VM and I was able to see the Payara self-signed cert is to localhost, not to localhost.localdomain.

In testing the change, I've corrected the `/home/glassfish/payara5` path as I changed them to have the entire version number (like Payara 4 did), but that doesn't seem to be the case in Payara 5.